### PR TITLE
fix: two more level menu open at the same time

### DIFF
--- a/lib/scaffold/src/components/PageNav/index.tsx
+++ b/lib/scaffold/src/components/PageNav/index.tsx
@@ -80,8 +80,14 @@ const Navigation = (props, context) => {
 
   useEffect(() => {
     const curSubNav = asideMenuConfig.find((menuConfig) => {
-      return menuConfig.children && menuConfig.children.some(child => child.path === pathname);
+      return menuConfig.children && checkChildPathExists(menuConfig);
     });
+
+    function checkChildPathExists(menuConfig) {
+      return menuConfig.children.some(child => {
+        return child.children ? checkChildPathExists(child) : child.path === pathname
+      })
+    }
 
     if (curSubNav && !openKeys.includes(curSubNav.name)) {
       setOpenKeys([...openKeys, curSubNav.name]);

--- a/lib/scaffold/src/components/PageNav/index.tsx
+++ b/lib/scaffold/src/components/PageNav/index.tsx
@@ -85,8 +85,8 @@ const Navigation = (props, context) => {
 
     function checkChildPathExists(menuConfig) {
       return menuConfig.children.some(child => {
-        return child.children ? checkChildPathExists(child) : child.path === pathname
-      })
+        return child.children ? checkChildPathExists(child) : child.path === pathname;
+      });
     }
 
     if (curSubNav && !openKeys.includes(curSubNav.name)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scaffold-generator",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "scaffold generator",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
表现：
本地调试，在浏览器访问 http://localhost:3333/，会出现两个 menu 同时展开的情况。

![image](https://user-images.githubusercontent.com/44047106/98795009-ae904a80-2444-11eb-949d-144057404b97.png)

预期：
实际上，只需要展开第一个 menu，因为现在根据路由展开（高亮）对应的路由。相关[issue]( https://github.com/alibaba/ice/issues/3595)
原因：
未考虑有多层菜单时候，path 为 '/' 的情况。如下图：
![image](https://user-images.githubusercontent.com/44047106/98263976-61ceee80-1fc2-11eb-9ba4-59f0d172953f.png)
 